### PR TITLE
Add `epochs` and `nodataaug` parameters to model training configuration that is logged to `wandb`

### DIFF
--- a/scripts/last_layer_finetuning.py
+++ b/scripts/last_layer_finetuning.py
@@ -56,6 +56,8 @@ def main(args, m_config, o_config):
                 num_blocks=args.num_blocks,
                 pretrained=args.pretrained,
                 label_smooth=args.label_smooth,
+                epochs=args.epochs,
+                nodataaug=not args.nodataaug,
             ),
             # Entity / mode / tags can be added here if you use them
             reinit=True,


### PR DESCRIPTION
This allows us to filter runs logged to `wandb` by these hyperparameters, rather than having to backfill them during analysis