### PR TITLE
Feat/add adamw optimizer expose lr and wd in argparser

### DIFF
--- a/scripts/last_layer_finetuning.py
+++ b/scripts/last_layer_finetuning.py
@@ -51,7 +51,7 @@ def main(args, m_config, o_config):
                 batch_size=args.batch_size,
                 num_vb_iters=args.num_update_iters,
                 optimizer=args.optimizer,
-                loss_fn=args.loss_function,
+                loss_fn=args.loss_fn,
                 embed_dim=args.embed_dim,
                 num_blocks=args.num_blocks,
                 pretrained=args.pretrained,

--- a/scripts/last_layer_finetuning.py
+++ b/scripts/last_layer_finetuning.py
@@ -56,6 +56,8 @@ def main(args, m_config, o_config):
                 num_blocks=args.num_blocks,
                 pretrained=args.pretrained,
                 label_smooth=args.label_smooth,
+                learning_rate=args.learning_rate,
+                weight_decay=args.weight_decay,
                 epochs=args.epochs,
                 nodataaug=not args.nodataaug,
             ),
@@ -147,6 +149,9 @@ def main(args, m_config, o_config):
     if 'lion' in o_config:
         optim = optax.lion(**o_config['lion'])
         mc_samples = 1
+    if 'adamw' in o_config:
+        optim = optax.adamw(**o_config['adamw'])
+        mc_samples = 1
     elif 'ivon' in o_config:
         lr_conf = o_config['lr']
         lr_conf['decay_steps'] = num_iters
@@ -222,7 +227,7 @@ def main(args, m_config, o_config):
 
 def build_argparser():
     parser = argparse.ArgumentParser(description="last layer finetuning")
-    parser.add_argument("-o", "--optimizer", choices=['ivon', 'lion', "cavi"], default='cavi', type=str)
+    parser.add_argument("-o", "--optimizer", choices=['ivon', 'lion', "cavi", "adamw"], default='cavi', type=str)
     parser.add_argument("--loss-fn", choices=['MSE', 'CrossEntropy', 'IBProbit'], default='IBProbit', type=str)
     parser.add_argument('--num-blocks', choices=[6, 12], default=6, type=int, help='Allowed number of blocks/layers')
     parser.add_argument('--embed-dim', choices=[512, 1024], default=512, type=int, help='Allowed embedding dimensions')
@@ -234,6 +239,8 @@ def build_argparser():
     parser.add_argument("-w", "--warmup", nargs='?', default=10, type=int)
     parser.add_argument("-bs", "--batch-size", nargs='?', default=64, type=int)
     parser.add_argument("-ls", "--label-smooth", nargs='?', default=0.0, type=float)
+    parser.add_argument("-lr", "--learning-rate" , nargs='?', default=1e-3, type=float, help='Learning rate for AdamW or Lion optimizers')
+    parser.add_argument("-wd", "--weight-decay", nargs='?', default=1e-2, type=float, help='Weight decay for AdamW or Lion optimizers')
     parser.add_argument("-mc", "--mc-samples", nargs='?', default=1, type=int)
     parser.add_argument("--num-update-iters", nargs='?', default=16, type=int, help='Number of CAVI iterations per mini-batch for Bayesian last layer')
     parser.add_argument("--pretrained", nargs='?', choices=['in21k', 'in21k_cifar'], default='in21k_cifar', type=str)
@@ -269,7 +276,9 @@ def build_configs(args):
             args.optimizer = 'lion'
 
     if args.optimizer == 'lion':
-        opt_config = {'lion': {'learning_rate': 5e-5, 'weight_decay': 1e-2}}
+        opt_config = {'lion': {'learning_rate': args.learning_rate, 'weight_decay': args.weight_decay}}
+    if args.optimizer == 'adamw':
+        opt_config = {'adamw': {'learning_rate': args.learning_rate, 'weight_decay': args.weight_decay}}
     if args.optimizer == 'ivon':
         opt_config = {
             'ivon': {'weight_decay': 1e-6, 'hess_init': 1.0, 'mc_samples': args.mc_samples, 'clip_radius': 1e3},


### PR DESCRIPTION
### Fixes
- Add Adam-W optimizer to optimizer choices in `scripts/last_layer_finetuning.py`.
- expose `learning_rate` and `weight_decay` arguments as options to the argparser (N.B.: not currently used to change the weight_decay parameter in `ivon`)


### Drive-by
- fix typo in config sent to wandb based on latest change of `loss_function` to `loss_fn` in CLI