### PR TITLE
Fix logging of nodataaug flag in wandb config to true value

### DIFF
--- a/scripts/last_layer_finetuning.py
+++ b/scripts/last_layer_finetuning.py
@@ -59,7 +59,7 @@ def main(args, m_config, o_config):
                 learning_rate=args.learning_rate,
                 weight_decay=args.weight_decay,
                 epochs=args.epochs,
-                nodataaug=not args.nodataaug,
+                nodataaug=args.nodataaug,
             ),
             # Entity / mode / tags can be added here if you use them
             reinit=True,


### PR DESCRIPTION
fix logging of `nodataaug` field in wandb config dict to be aligned with CLI arg (currently, it logs to the opposite of the nodataaug value) to address #14 