### PR TITLE
Pass environment variable to offset configuration indices in case of array job limits

### DIFF
--- a/src/slurm/jobs/slurm_run_config_docker.sh
+++ b/src/slurm/jobs/slurm_run_config_docker.sh
@@ -15,6 +15,9 @@ cd "$REPO_ROOT"
 # 2) Make the repo root discoverable for the adapter inside the container
 export BLLARSE_REPO_ROOT="$REPO_ROOT"
 
+INDEX_OFFSET="${INDEX_OFFSET:-0}"
+CONFIG_IDX=$((SLURM_ARRAY_TASK_ID+INDEX_OFFSET))
+echo "[bllarse] SLURM_ARRAY_TASK_ID=${SLURM_ARRAY_TASK_ID}  INDEX_OFFSET=${INDEX_OFFSET}  CONFIG_IDX=${CONFIG_IDX}"
 # 3) Call your container wrapper; inside, activate the venv and run the config
 #    NOTE: VENV_NAME and BLLARSE_SWEEP_SOURCE are set by run_sweep.py
 scripts/start_docker_sbatch.sh \
@@ -24,4 +27,4 @@ scripts/start_docker_sbatch.sh \
             cd \"$REPO_ROOT\"; \
             if [[ -n \"${VENV_NAME:-}\" && -f \"${VENV_NAME}/bin/activate\" ]]; then source \"${VENV_NAME}/bin/activate\"; \
             elif [[ -f .venv/bin/activate ]]; then source .venv/bin/activate; fi; \
-            python src/bllarse/tools/run_config.py \"${BLLARSE_SWEEP_SOURCE}\" \"${SLURM_ARRAY_TASK_ID}\""
+            python src/bllarse/tools/run_config.py \"${BLLARSE_SWEEP_SOURCE}\" \"${CONFIG_IDX}\""


### PR DESCRIPTION
Many SLURM clusters have max array job limits (`MaxArraySize`, the number of simultaneous array jobs that can be run), often defaults to 1001. In case you're indexing into a list of hyperparameter configurations with $SLURM_ARRAY_TASK_ID and there are more than MaxArraySize jobs, you can now use an $INDEX_OFFSET variable to increment the $SLURM_ARRAY_TASK_ID before indexing into the configuration list 