### PR TITLE
Only log optimizer-specific hyperparameters to wandb config

### DIFF
--- a/scripts/full_network_finetuning.py
+++ b/scripts/full_network_finetuning.py
@@ -38,6 +38,43 @@ from bllarse.utils import (
     save_checkpoint_bundle,
 )
 
+
+def _build_wandb_config(args, o_config):
+    """Return shared run metadata plus optimizer-specific hyperparameters."""
+    config_dict = dict(
+        dataset=args.dataset,
+        seed=args.seed,
+        batch_size=args.batch_size,
+        num_vb_iters=args.num_update_iters,
+        optimizer=args.optimizer,
+        loss_fn=args.loss_fn,
+        embed_dim=args.embed_dim,
+        num_blocks=args.num_blocks,
+        pretrained=args.pretrained,
+        label_smooth=args.label_smooth,
+        epochs=args.epochs,
+        nodataaug=args.nodataaug,
+    )
+
+    if 'ivon' in o_config:
+        config_dict.update(
+            dict(
+                ivon_weight_decay=args.ivon_weight_decay,
+                ivon_hess_init=args.ivon_hess_init,
+                mc_samples=args.mc_samples,
+            )
+        )
+    else:
+        config_dict.update(
+            dict(
+                learning_rate=args.learning_rate,
+                weight_decay=args.weight_decay,
+            )
+        )
+
+    return config_dict
+
+
 def main(args, m_config, o_config):
     dataset = args.dataset
     seed = args.seed
@@ -54,24 +91,7 @@ def main(args, m_config, o_config):
             project="bllarse_experiments",
             id=args.uid if args.uid else wandb.util.generate_id(),
             group=args.group_id,      # <-- lets you filter by group_id in the UI
-            config=dict(              # everything you later want to slice on
-                dataset=args.dataset,
-                seed=args.seed,
-                batch_size=args.batch_size,
-                num_vb_iters=args.num_update_iters,
-                optimizer=args.optimizer,
-                loss_fn=args.loss_fn,
-                embed_dim=args.embed_dim,
-                num_blocks=args.num_blocks,
-                pretrained=args.pretrained,
-                label_smooth=args.label_smooth,
-                learning_rate=args.learning_rate,
-                weight_decay=args.weight_decay,
-                ivon_weight_decay=args.ivon_weight_decay,
-                ivon_hess_init=args.ivon_hess_init,
-                epochs=args.epochs,
-                nodataaug=args.nodataaug,
-            ),
+            config=_build_wandb_config(args, o_config),
             # Entity / mode / tags can be added here if you use them
             reinit=True,
       )


### PR DESCRIPTION
### Summary
To address #21. Builds W&B configs in both `scripts/last_layer_finetuning.py` and `scripts/full_network_finetuning.py` with a helper function that keeps shared metadata but only logs optimizer-specific hyperparameters:
- Lion/AdamW runs record just learning rate/weight decay as `learning_rate` and `weight_decay`, respectively.
- IVON runs `hess_init` as `ivon_hess_init`, `weight_decay` as `ivon_weight_decay` and `mc_samples`
-  CAVI runs (for last layer finetuning only) include only `num_vb_iters`

This eliminates redundant/unused entries for other optimizers that are not used