### PR TITLE
[codex] Pass through HF_TOKEN and PYTHONPATH in Docker sweeps

### DIFF
--- a/scripts/start_docker_sbatch.sh
+++ b/scripts/start_docker_sbatch.sh
@@ -28,6 +28,8 @@ passthrough_vars=(
   MLFLOW_TRACKING_URI
   MLFLOW_EXPERIMENT_NAME
   BLLARSE_REPO_ROOT
+  HF_TOKEN
+  PYTHONPATH
 )
 for var_name in "${passthrough_vars[@]}"; do
   if [[ -n "${!var_name:-}" ]]; then

--- a/src/slurm/jobs/slurm_run_config_docker.sh
+++ b/src/slurm/jobs/slurm_run_config_docker.sh
@@ -14,6 +14,7 @@ cd "$REPO_ROOT"
 
 # 2) Make the repo root discoverable for the adapter inside the container
 export BLLARSE_REPO_ROOT="$REPO_ROOT"
+export PYTHONPATH="${REPO_ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}"
 
 INDEX_OFFSET="${INDEX_OFFSET:-0}"
 CONFIG_IDX=$((SLURM_ARRAY_TASK_ID+INDEX_OFFSET))


### PR DESCRIPTION
## What changed

This PR makes two small Docker/SLURM launcher fixes that are useful outside the context they were added in (the RoBERTa/MNLI experiments on `bayesian_finetuning_roberta`:

- pass `HF_TOKEN` through `scripts/start_docker_sbatch.sh`
- pass `PYTHONPATH` through `scripts/start_docker_sbatch.sh` and prepend `${REPO_ROOT}/src` inside `src/slurm/jobs/slurm_run_config_docker.sh`

## Why it changed

Some sweep and cache workflows need Hugging Face authentication inside the container, and some runs need the container job to prefer the checked-out repo code over an older installed package in the venv.

Without these passthroughs:

- Hugging Face pull/push inside Docker jobs can fail because the token is not present in the container env
- `python -m ...` can resolve a stale installed package rather than the current checkout, which is especially painful when iterating on sweep/launcher code

## Impact

This improves generic sweep reliability for any experiment launched through the Docker SLURM path.

## Validation

- `bash -n scripts/start_docker_sbatch.sh`
- `bash -n src/slurm/jobs/slurm_run_config_docker.sh`
