### PR TITLE
Add generic SLURM sweep infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,62 @@ source .venv/bin/activate
 python scripts/finetuning.py
 ```
 
+## SLURM sweeps
+
+Python sweep files provide two functions:
+
+```python
+def create_configs() -> list[dict]:
+    ...
+
+def run(config: dict) -> None:
+    ...
+```
+
+[`bllarse_sweeps/finetuning_demo.py`](bllarse_sweeps/finetuning_demo.py)
+is a small example using the standard finetuning entry point. From a SLURM
+login node, launch it as a GPU array:
+
+```bash
+source .venv/bin/activate
+
+python -m bllarse.tools.run_sweep \
+  bllarse_sweeps/finetuning_demo.py \
+  --venv .venv \
+  --max-concurrent 4 \
+  --cpus-per-task 8 \
+  --job-name finetuning_demo
+```
+
+The default job uses `scripts/start_docker_sbatch.sh` and expects an image
+named `bllarse-dev` on each allocated node. Override the image and Docker
+shared-memory allocation when needed:
+
+```bash
+export BLLARSE_DOCKER_IMAGE=bllarse-dev
+export BLLARSE_DOCKER_SHM_SIZE=16g
+```
+
+Use `--job-script src/slurm/jobs/slurm_run_config.sh` to run directly in the
+host virtual environment instead. `--dry-run` validates the sweep and prints
+the `sbatch` command without submitting it.
+
+Large sweeps can be split while preserving the original config indices:
+
+```bash
+python -m bllarse.tools.run_sweep bllarse_sweeps/my_sweep.py \
+  --index-offset 0 --num-jobs 1000 --max-concurrent 50
+
+python -m bllarse.tools.run_sweep bllarse_sweeps/my_sweep.py \
+  --index-offset 1000 --num-jobs 1000 --max-concurrent 50
+```
+
+When a selected config sets `enable_mlflow=True`, the launcher creates one
+MLflow parent run and passes its ID to every array task. Use
+`--parent-run-id <RUN_ID>` to attach another submission to an existing parent.
+Parent creation is fail-loud: if MLflow cannot create the requested parent,
+the array is not submitted.
+
 ## 🔄 Updating Git-based dependencies
 
 Some dependencies in `pyproject.toml` are installed directly from GitHub (e.g. `blrax`, `mlpox`).  

--- a/bllarse_sweeps/finetuning_demo.py
+++ b/bllarse_sweeps/finetuning_demo.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from bllarse.tools.adapters import run_training_from_config
+from bllarse.tools.config import get_config_grid
+
+
+def _create_config(seed: int, num_update_iters: int) -> dict[str, Any]:
+    return {
+        "dataset": "cifar10",
+        "tune_mode": "last_layer",
+        "loss_fn": "IBProbit",
+        "epochs": 1,
+        "batch_size": 64,
+        "num_update_iters": num_update_iters,
+        "nodataaug": True,
+        "pretrained": "in21k_cifar",
+        "seed": seed,
+        "enable_mlflow": True,
+        "group_id": "finetuning_demo",
+        "uid": f"seed{seed}_iters{num_update_iters}",
+    }
+
+
+def create_configs() -> list[dict[str, Any]]:
+    return get_config_grid(
+        _create_config,
+        {
+            "seed": [0, 1],
+            "num_update_iters": [8, 16],
+        },
+    )
+
+
+def run(config: dict[str, Any]) -> None:
+    run_training_from_config(config)

--- a/scripts/start_docker_sbatch.sh
+++ b/scripts/start_docker_sbatch.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${SLURM_JOB_GPUS:-}" ]]; then
+  echo "[bllarse] ERROR: SLURM_JOB_GPUS is not set; request a GPU for this job." >&2
+  exit 2
+fi
+
+host_user="${USER:-$(id -un)}"
+host_logname="${LOGNAME:-$host_user}"
+docker_image="${BLLARSE_DOCKER_IMAGE:-bllarse-dev}"
+docker_shm_size="${BLLARSE_DOCKER_SHM_SIZE:-8g}"
+
+docker_args=(
+  --rm
+  --gpus "device=${SLURM_JOB_GPUS}"
+  --shm-size "$docker_shm_size"
+  -e "HOME=$HOME"
+  -e "USER=$host_user"
+  -e "LOGNAME=$host_logname"
+  -v "$HOME:$HOME"
+  -v "$(pwd):$(pwd)"
+  -w "$(pwd)"
+  -u "$(id -u):$(id -g)"
+)
+
+passthrough_vars=(
+  BLLARSE_REPO_ROOT
+  BLLARSE_SWEEP_SOURCE
+  CONFIG_IDX
+  HF_TOKEN
+  INDEX_OFFSET
+  MLFLOW_EXPERIMENT_NAME
+  MLFLOW_PARENT_RUN_ID
+  MLFLOW_TRACKING_PASSWORD
+  MLFLOW_TRACKING_URI
+  MLFLOW_TRACKING_USERNAME
+  PYTHONPATH
+  VENV_NAME
+)
+for variable in "${passthrough_vars[@]}"; do
+  if [[ -n "${!variable:-}" ]]; then
+    docker_args+=(--env "$variable")
+  fi
+done
+
+if [[ -n "${SLURM_CPUS_PER_TASK:-}" ]]; then
+  docker_args+=(--cpus "$SLURM_CPUS_PER_TASK")
+fi
+
+if [[ -n "${TORCHINDUCTOR_CACHE_DIR:-}" ]]; then
+  mkdir -p "$TORCHINDUCTOR_CACHE_DIR"
+  docker_args+=(
+    -e "TORCHINDUCTOR_CACHE_DIR=$TORCHINDUCTOR_CACHE_DIR"
+    -v "$TORCHINDUCTOR_CACHE_DIR:$TORCHINDUCTOR_CACHE_DIR"
+  )
+fi
+
+if ! docker image inspect "$docker_image" >/dev/null 2>&1; then
+  echo "[bllarse] ERROR: Docker image '$docker_image' is unavailable on $(hostname)." >&2
+  echo "[bllarse] Build it on that node or exclude the node from the sweep." >&2
+  exit 125
+fi
+
+exec docker run "${docker_args[@]}" "$docker_image" "$@"

--- a/src/bllarse/tools/__init__.py
+++ b/src/bllarse/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for launching configuration-driven experiments."""

--- a/src/bllarse/tools/adapters.py
+++ b/src/bllarse/tools/adapters.py
@@ -1,0 +1,80 @@
+import os
+from argparse import Namespace
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from bllarse.tools.module import get_module_from_source_path
+
+
+def config_to_argv(config: Mapping[str, Any]) -> list[str]:
+    """Convert a config mapping to conventional argparse flags."""
+    argv: list[str] = []
+    for key, value in config.items():
+        if value is None:
+            continue
+
+        flag = "--" + key.replace("_", "-")
+        if isinstance(value, bool):
+            if value:
+                argv.append(flag)
+            continue
+
+        argv.extend((flag, str(value)))
+    return argv
+
+
+def _resolve_repo_root(script_path: str | Path) -> Path:
+    env_root = os.environ.get("BLLARSE_REPO_ROOT")
+    if env_root:
+        return Path(env_root).expanduser().resolve()
+
+    relative_script = Path(script_path)
+    for parent in Path(__file__).resolve().parents:
+        if (parent / relative_script).is_file():
+            return parent
+        if (parent / "scripts" / relative_script).is_file():
+            return parent
+
+    return Path.cwd().resolve()
+
+
+def _resolve_script_path(script_path: str | Path) -> Path:
+    requested = Path(script_path).expanduser()
+    if requested.is_absolute():
+        resolved = requested.resolve()
+    else:
+        repo_root = _resolve_repo_root(requested)
+        direct = repo_root / requested
+        resolved = direct if direct.is_file() else repo_root / "scripts" / requested
+
+    if not resolved.is_file():
+        raise FileNotFoundError(
+            f"Could not find training script {resolved}. "
+            "Set BLLARSE_REPO_ROOT when launching outside the repository."
+        )
+    return resolved
+
+
+def run_training_from_config(config: Mapping[str, Any]) -> None:
+    """Run the repository's standard finetuning script from a config."""
+    run_script_from_config("scripts/finetuning.py", config)
+
+
+def run_script_from_config(
+    script_path: str | Path,
+    config: Mapping[str, Any],
+) -> None:
+    """Parse a config with a script's CLI and invoke its main function."""
+    module = get_module_from_source_path(_resolve_script_path(script_path))
+    build_argparser: Callable[[], Any] = module.build_argparser
+    parser = build_argparser()
+    args: Namespace = parser.parse_args(config_to_argv(config))
+
+    train_main = module.main
+    if not hasattr(module, "build_configs"):
+        train_main(args)
+        return
+
+    model_config, optimizer_config = module.build_configs(args)
+    train_main(args, model_config, optimizer_config)

--- a/src/bllarse/tools/config.py
+++ b/src/bllarse/tools/config.py
@@ -1,0 +1,15 @@
+import itertools
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+
+def get_config_grid(
+    create_config: Callable[..., Any],
+    values: Mapping[str, Sequence[Any]],
+) -> list[Any]:
+    """Build configs over the Cartesian product of the supplied values."""
+    keys = list(values)
+    return [
+        create_config(**dict(zip(keys, combination, strict=True)))
+        for combination in itertools.product(*(values[key] for key in keys))
+    ]

--- a/src/bllarse/tools/module.py
+++ b/src/bllarse/tools/module.py
@@ -1,0 +1,27 @@
+import hashlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def get_module_from_source_path(source_path: str | Path) -> ModuleType:
+    """Load a Python module from a source file."""
+    source = Path(source_path).expanduser().resolve()
+    if not source.is_file():
+        raise FileNotFoundError(f"Python source file not found: {source}")
+
+    digest = hashlib.sha256(str(source).encode()).hexdigest()[:12]
+    module_name = f"_bllarse_dynamic_{source.stem}_{digest}"
+    spec = importlib.util.spec_from_file_location(module_name, source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not create an import specification for {source}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module

--- a/src/bllarse/tools/run_config.py
+++ b/src/bllarse/tools/run_config.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import argparse
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from bllarse.tools.module import get_module_from_source_path
+
+
+def _config_uses_mlflow(config: Any) -> bool:
+    return isinstance(config, Mapping) and bool(config.get("enable_mlflow", False))
+
+
+def run_config(sweep_source: str | Path, config_idx: int) -> None:
+    """Run one indexed configuration from a sweep source file."""
+    sweep = get_module_from_source_path(sweep_source)
+    configs = sweep.create_configs()
+
+    if config_idx < 0 or config_idx >= len(configs):
+        raise IndexError(f"config_idx={config_idx} out of range (0..{len(configs) - 1})")
+
+    config = configs[config_idx]
+    if _config_uses_mlflow(config):
+        from bllarse.mlflow_utils import load_mlflow_env_defaults
+
+        load_mlflow_env_defaults()
+        if not os.environ.get("MLFLOW_PARENT_RUN_ID"):
+            print(
+                "[bllarse] WARNING: MLFLOW_PARENT_RUN_ID is not set; "
+                "this run will not be nested under a sweep parent."
+            )
+
+    sweep.run(config)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("sweep_source", type=Path)
+    parser.add_argument("config_idx", type=int)
+    args = parser.parse_args()
+    run_config(args.sweep_source, args.config_idx)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bllarse/tools/run_sweep.py
+++ b/src/bllarse/tools/run_sweep.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Submit a Python-defined experiment sweep as a SLURM array."""
+
+import argparse
+import os
+import shlex
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from bllarse.tools.module import get_module_from_source_path
+
+DEFAULT_JOB_SCRIPT = Path("src/slurm/jobs/slurm_run_config_docker.sh")
+
+
+def _config_value(config: Any, key: str, default: Any = None) -> Any:
+    if isinstance(config, Mapping):
+        return config.get(key, default)
+    return default
+
+
+def _sweep_name(configs: Sequence[Any], sweep_source: Path) -> str:
+    group_ids = {
+        value
+        for config in configs
+        if (value := _config_value(config, "group_id"))
+    }
+    if len(group_ids) == 1:
+        return str(group_ids.pop())
+    if len(group_ids) > 1:
+        print(
+            "[bllarse] WARNING: Multiple group_id values found; "
+            f"using the sweep filename '{sweep_source.stem}' for the parent run."
+        )
+    return sweep_source.stem
+
+
+def _create_mlflow_parent(
+    configs: Sequence[Any],
+    sweep_source: Path,
+    *,
+    total: int,
+    chunk_size: int,
+    chunk_offset: int,
+) -> str:
+    from bllarse.mlflow_utils import load_mlflow_env_defaults
+
+    load_mlflow_env_defaults()
+    import mlflow
+
+    tracking_uri = (
+        _config_value(configs[0], "mlflow_tracking_uri")
+        or os.environ.get("MLFLOW_TRACKING_URI")
+    )
+    experiment = (
+        _config_value(configs[0], "mlflow_experiment")
+        or os.environ.get("MLFLOW_EXPERIMENT_NAME")
+        or "bllarse"
+    )
+    name = _sweep_name(configs, sweep_source)
+
+    if tracking_uri:
+        mlflow.set_tracking_uri(tracking_uri)
+    mlflow.set_experiment(experiment)
+    tags = {
+        "sweep_source": str(sweep_source),
+        "sweep_name": name,
+        "group_id": name,
+        "is_parent": "true",
+        "sweep_size_total": str(total),
+        "sweep_chunk_size": str(chunk_size),
+        "sweep_chunk_offset": str(chunk_offset),
+    }
+    with mlflow.start_run(run_name=name, tags=tags) as parent:
+        return parent.info.run_id
+
+
+def run_sweep(
+    sweep_source: str | Path,
+    *,
+    venv_name: str = ".venv",
+    max_concurrent: int = 7,
+    job_name: str | None = None,
+    job_script: str | Path = DEFAULT_JOB_SCRIPT,
+    index_offset: int = 0,
+    num_jobs: int | None = None,
+    cpus_per_task: int | None = None,
+    parent_run_id: str | None = None,
+    exclude_nodes: str | None = None,
+    dry_run: bool = False,
+) -> subprocess.CompletedProcess[str] | None:
+    """Validate and submit a sweep, returning the completed sbatch process."""
+    source = Path(sweep_source).expanduser().resolve()
+    script = Path(job_script).expanduser().resolve()
+    if not script.is_file():
+        raise FileNotFoundError(f"SLURM job script not found: {script}")
+    if max_concurrent <= 0:
+        raise ValueError("max_concurrent must be > 0")
+    if cpus_per_task is not None and cpus_per_task <= 0:
+        raise ValueError("cpus_per_task must be > 0")
+
+    sweep = get_module_from_source_path(source)
+    configs = sweep.create_configs()
+    total = len(configs)
+    if total == 0:
+        raise ValueError("create_configs() returned an empty sequence")
+    if index_offset < 0 or index_offset >= total:
+        raise ValueError(f"index_offset={index_offset} out of range (0..{total - 1})")
+
+    chunk_size = total - index_offset if num_jobs is None else num_jobs
+    if chunk_size <= 0:
+        raise ValueError("num_jobs must be > 0")
+    if index_offset + chunk_size > total:
+        raise ValueError(
+            f"index_offset + num_jobs exceeds the {total} available configs"
+        )
+
+    selected_configs = configs[index_offset:index_offset + chunk_size]
+    mlflow_configs = [
+        config
+        for config in selected_configs
+        if bool(_config_value(config, "enable_mlflow", False))
+    ]
+    uses_mlflow = bool(mlflow_configs)
+    if parent_run_id and not uses_mlflow:
+        print(
+            "[bllarse] WARNING: --parent-run-id was supplied, but no selected "
+            "configuration enables MLflow."
+        )
+
+    env = os.environ.copy()
+    if uses_mlflow and not parent_run_id and not dry_run:
+        parent_run_id = _create_mlflow_parent(
+            mlflow_configs,
+            source,
+            total=total,
+            chunk_size=chunk_size,
+            chunk_offset=index_offset,
+        )
+        print(f"[bllarse] MLflow parent run id: {parent_run_id}")
+
+    env.update(
+        {
+            "BLLARSE_SWEEP_SOURCE": str(source),
+            "VENV_NAME": venv_name,
+            "INDEX_OFFSET": str(index_offset),
+        }
+    )
+    if parent_run_id:
+        env["MLFLOW_PARENT_RUN_ID"] = parent_run_id
+    for key in (
+        "MLFLOW_TRACKING_URI",
+        "MLFLOW_TRACKING_USERNAME",
+        "MLFLOW_TRACKING_PASSWORD",
+    ):
+        if value := os.environ.get(key):
+            env[key] = value
+
+    command = [
+        "sbatch",
+        "--export=ALL",
+        f"--array=0-{chunk_size - 1}%{max_concurrent}",
+        f"--job-name={job_name or source.stem}",
+    ]
+    if cpus_per_task is not None:
+        command.append(f"--cpus-per-task={cpus_per_task}")
+    if exclude_nodes:
+        command.append(f"--exclude={exclude_nodes}")
+    command.append(str(script))
+
+    if dry_run:
+        print(shlex.join(command))
+        return None
+    Path("slurm_logs").mkdir(exist_ok=True)
+    return subprocess.run(command, env=env, check=True, text=True)
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sweep_source", type=Path)
+    parser.add_argument("--venv", default=".venv")
+    parser.add_argument("--max-concurrent", type=int, default=7)
+    parser.add_argument("--job-name")
+    parser.add_argument("--job-script", type=Path, default=DEFAULT_JOB_SCRIPT)
+    parser.add_argument("--cpus-per-task", type=int)
+    parser.add_argument("--index-offset", type=int, default=0)
+    parser.add_argument("--num-jobs", type=int)
+    parser.add_argument("--parent-run-id")
+    parser.add_argument("--exclude-nodes")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main() -> None:
+    args = build_argparser().parse_args()
+    run_sweep(
+        args.sweep_source,
+        venv_name=args.venv,
+        max_concurrent=args.max_concurrent,
+        job_name=args.job_name,
+        job_script=args.job_script,
+        index_offset=args.index_offset,
+        num_jobs=args.num_jobs,
+        cpus_per_task=args.cpus_per_task,
+        parent_run_id=args.parent_run_id,
+        exclude_nodes=args.exclude_nodes,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/slurm/jobs/slurm_run_config.sh
+++ b/src/slurm/jobs/slurm_run_config.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#SBATCH --time=08:00:00
+#SBATCH --mem=40G
+#SBATCH -G 1
+#SBATCH --output=slurm_logs/%x.%A_%a.out
+#SBATCH --error=slurm_logs/%x.%A_%a.err
+
+set -euo pipefail
+
+repo_root="${SLURM_SUBMIT_DIR:-$(pwd)}"
+cd "$repo_root"
+
+if [[ "$VENV_NAME" = /* ]]; then
+  venv_dir="$VENV_NAME"
+else
+  venv_dir="$repo_root/$VENV_NAME"
+fi
+if [[ ! -f "$venv_dir/bin/activate" ]]; then
+  echo "[bllarse] ERROR: virtual environment not found at $venv_dir" >&2
+  exit 2
+fi
+
+source "$venv_dir/bin/activate"
+export PYTHONPATH="${repo_root}/src${PYTHONPATH:+:${PYTHONPATH}}"
+config_idx="$((SLURM_ARRAY_TASK_ID + ${INDEX_OFFSET:-0}))"
+python -m bllarse.tools.run_config "$BLLARSE_SWEEP_SOURCE" "$config_idx"

--- a/src/slurm/jobs/slurm_run_config_docker.sh
+++ b/src/slurm/jobs/slurm_run_config_docker.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#SBATCH --time=12:00:00
+#SBATCH --mem=40G
+#SBATCH -G 1
+#SBATCH --output=slurm_logs/%x.%A_%a.out
+#SBATCH --error=slurm_logs/%x.%A_%a.err
+
+set -euo pipefail
+
+repo_root="${SLURM_SUBMIT_DIR:-$(pwd)}"
+cd "$repo_root"
+
+export BLLARSE_REPO_ROOT="$repo_root"
+export PYTHONPATH="${repo_root}/src${PYTHONPATH:+:${PYTHONPATH}}"
+export INDEX_OFFSET="${INDEX_OFFSET:-0}"
+export CONFIG_IDX="$((SLURM_ARRAY_TASK_ID + INDEX_OFFSET))"
+
+echo "[bllarse] task=${SLURM_ARRAY_TASK_ID} offset=${INDEX_OFFSET} config=${CONFIG_IDX}"
+
+scripts/start_docker_sbatch.sh bash -lc '
+  set -euo pipefail
+  cd "$BLLARSE_REPO_ROOT"
+
+  if [[ "$VENV_NAME" = /* ]]; then
+    venv_dir="$VENV_NAME"
+  else
+    venv_dir="$BLLARSE_REPO_ROOT/$VENV_NAME"
+  fi
+  if [[ ! -f "$venv_dir/bin/activate" ]]; then
+    echo "[bllarse] ERROR: virtual environment not found at $venv_dir" >&2
+    exit 2
+  fi
+
+  source "$venv_dir/bin/activate"
+  python -m bllarse.tools.run_config "$BLLARSE_SWEEP_SOURCE" "$CONFIG_IDX"
+'

--- a/tests/tools/test_adapters.py
+++ b/tests/tools/test_adapters.py
@@ -1,0 +1,62 @@
+from bllarse.tools.adapters import config_to_argv, run_script_from_config
+
+
+def test_config_to_argv_handles_values_and_boolean_flags():
+    assert config_to_argv(
+        {
+            "batch_size": 64,
+            "nodataaug": True,
+            "disabled_flag": False,
+            "optional": None,
+        }
+    ) == ["--batch-size", "64", "--nodataaug"]
+
+
+def test_run_script_from_config_supports_single_argument_main(tmp_path, monkeypatch):
+    output = tmp_path / "result.txt"
+    script = tmp_path / "runner.py"
+    script.write_text(
+        "import argparse\n"
+        "import os\n"
+        "from pathlib import Path\n"
+        "\n"
+        "def build_argparser():\n"
+        "    parser = argparse.ArgumentParser()\n"
+        "    parser.add_argument('--value', type=int)\n"
+        "    return parser\n"
+        "\n"
+        "def main(args):\n"
+        "    Path(os.environ['ADAPTER_TEST_OUTPUT']).write_text(str(args.value))\n"
+    )
+    monkeypatch.setenv("ADAPTER_TEST_OUTPUT", str(output))
+
+    run_script_from_config(script, {"value": 17})
+
+    assert output.read_text() == "17"
+
+
+def test_run_script_from_config_supports_build_configs(tmp_path, monkeypatch):
+    output = tmp_path / "result.txt"
+    script = tmp_path / "runner_with_configs.py"
+    script.write_text(
+        "import argparse\n"
+        "import os\n"
+        "from pathlib import Path\n"
+        "\n"
+        "def build_argparser():\n"
+        "    parser = argparse.ArgumentParser()\n"
+        "    parser.add_argument('--value', type=int)\n"
+        "    return parser\n"
+        "\n"
+        "def build_configs(args):\n"
+        "    return {'model': args.value}, {'optimizer': args.value + 1}\n"
+        "\n"
+        "def main(args, model_config, optimizer_config):\n"
+        "    result = model_config['model'] + optimizer_config['optimizer']\n"
+        "    Path(os.environ['ADAPTER_TEST_OUTPUT']).write_text(str(result))\n"
+    )
+    monkeypatch.setenv("ADAPTER_TEST_OUTPUT", str(output))
+
+    run_script_from_config(script, {"value": 4})
+
+    assert output.read_text() == "9"

--- a/tests/tools/test_config.py
+++ b/tests/tools/test_config.py
@@ -1,0 +1,13 @@
+from bllarse.tools.config import get_config_grid
+
+
+def test_get_config_grid_builds_cartesian_product_in_key_order():
+    configs = get_config_grid(
+        lambda seed, batch_size: (seed, batch_size),
+        {
+            "seed": [0, 1],
+            "batch_size": [64, 128],
+        },
+    )
+
+    assert configs == [(0, 64), (0, 128), (1, 64), (1, 128)]

--- a/tests/tools/test_module.py
+++ b/tests/tools/test_module.py
@@ -1,0 +1,32 @@
+import pytest
+
+from bllarse.tools.module import get_module_from_source_path
+
+
+def test_get_module_from_source_path_loads_module(tmp_path):
+    source = tmp_path / "example.py"
+    source.write_text("VALUE = 42\n")
+
+    module = get_module_from_source_path(source)
+
+    assert module.VALUE == 42
+
+
+def test_get_module_from_source_path_supports_dataclasses(tmp_path):
+    source = tmp_path / "config.py"
+    source.write_text(
+        "from dataclasses import dataclass\n"
+        "\n"
+        "@dataclass\n"
+        "class Config:\n"
+        "    seed: int\n"
+    )
+
+    module = get_module_from_source_path(source)
+
+    assert module.Config(seed=3).seed == 3
+
+
+def test_get_module_from_source_path_rejects_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError, match="Python source file not found"):
+        get_module_from_source_path(tmp_path / "missing.py")

--- a/tests/tools/test_run_config.py
+++ b/tests/tools/test_run_config.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+import pytest
+
+import bllarse.tools.run_config as run_config_module
+
+
+def test_run_config_selects_requested_config(monkeypatch):
+    seen = []
+    sweep = SimpleNamespace(
+        create_configs=lambda: [{"seed": 0}, {"seed": 1}],
+        run=seen.append,
+    )
+    monkeypatch.setattr(
+        run_config_module,
+        "get_module_from_source_path",
+        lambda _: sweep,
+    )
+
+    run_config_module.run_config("unused.py", 1)
+
+    assert seen == [{"seed": 1}]
+
+
+def test_run_config_rejects_invalid_index(monkeypatch):
+    sweep = SimpleNamespace(create_configs=lambda: [{"seed": 0}], run=lambda _: None)
+    monkeypatch.setattr(
+        run_config_module,
+        "get_module_from_source_path",
+        lambda _: sweep,
+    )
+
+    with pytest.raises(IndexError, match="out of range"):
+        run_config_module.run_config("unused.py", 1)

--- a/tests/tools/test_run_sweep.py
+++ b/tests/tools/test_run_sweep.py
@@ -1,0 +1,151 @@
+import subprocess
+
+import pytest
+
+import bllarse.tools.run_sweep as run_sweep_module
+
+
+def _write_sweep(tmp_path, configs):
+    source = tmp_path / "sweep.py"
+    source.write_text(
+        "def create_configs():\n"
+        f"    return {configs!r}\n"
+        "\n"
+        "def run(config):\n"
+        "    return None\n"
+    )
+    return source
+
+
+def _write_job_script(tmp_path):
+    script = tmp_path / "job.sh"
+    script.write_text("#!/usr/bin/env bash\n")
+    return script
+
+
+def test_run_sweep_submits_chunk_with_expected_environment(tmp_path, monkeypatch):
+    source = _write_sweep(tmp_path, [{"seed": 0}, {"seed": 1}, {"seed": 2}])
+    script = _write_job_script(tmp_path)
+    captured = {}
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(run_sweep_module.subprocess, "run", fake_run)
+
+    run_sweep_module.run_sweep(
+        source,
+        job_script=script,
+        index_offset=1,
+        num_jobs=2,
+        max_concurrent=3,
+        cpus_per_task=8,
+        exclude_nodes="node4",
+        job_name="demo",
+    )
+
+    assert captured["command"] == [
+        "sbatch",
+        "--export=ALL",
+        "--array=0-1%3",
+        "--job-name=demo",
+        "--cpus-per-task=8",
+        "--exclude=node4",
+        str(script.resolve()),
+    ]
+    env = captured["kwargs"]["env"]
+    assert env["BLLARSE_SWEEP_SOURCE"] == str(source.resolve())
+    assert env["INDEX_OFFSET"] == "1"
+    assert env["VENV_NAME"] == ".venv"
+    assert (tmp_path / "slurm_logs").is_dir()
+
+
+def test_run_sweep_reuses_mlflow_parent_without_creating_one(tmp_path, monkeypatch):
+    source = _write_sweep(tmp_path, [{"enable_mlflow": True}])
+    script = _write_job_script(tmp_path)
+    captured = {}
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        run_sweep_module,
+        "_create_mlflow_parent",
+        lambda *args, **kwargs: pytest.fail("parent should be reused"),
+    )
+
+    def fake_run(command, **kwargs):
+        captured["env"] = kwargs["env"]
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(run_sweep_module.subprocess, "run", fake_run)
+
+    run_sweep_module.run_sweep(
+        source,
+        job_script=script,
+        parent_run_id="parent-123",
+    )
+
+    assert captured["env"]["MLFLOW_PARENT_RUN_ID"] == "parent-123"
+
+
+def test_run_sweep_does_not_submit_when_mlflow_parent_creation_fails(
+    tmp_path,
+    monkeypatch,
+):
+    source = _write_sweep(tmp_path, [{"enable_mlflow": True}])
+    script = _write_job_script(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    def fail_parent(*args, **kwargs):
+        raise RuntimeError("tracking unavailable")
+
+    monkeypatch.setattr(run_sweep_module, "_create_mlflow_parent", fail_parent)
+    monkeypatch.setattr(
+        run_sweep_module.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("sbatch must not be called"),
+    )
+
+    with pytest.raises(RuntimeError, match="tracking unavailable"):
+        run_sweep_module.run_sweep(source, job_script=script)
+
+
+def test_dry_run_has_no_mlflow_or_submission_side_effects(tmp_path, monkeypatch):
+    source = _write_sweep(tmp_path, [{"enable_mlflow": True}])
+    script = _write_job_script(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        run_sweep_module,
+        "_create_mlflow_parent",
+        lambda *args, **kwargs: pytest.fail("dry-run must not create a parent"),
+    )
+    monkeypatch.setattr(
+        run_sweep_module.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("dry-run must not call sbatch"),
+    )
+
+    result = run_sweep_module.run_sweep(source, job_script=script, dry_run=True)
+
+    assert result is None
+    assert not (tmp_path / "slurm_logs").exists()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    (
+        ({"max_concurrent": 0}, "max_concurrent"),
+        ({"cpus_per_task": 0}, "cpus_per_task"),
+        ({"index_offset": 3}, "index_offset"),
+        ({"num_jobs": 0}, "num_jobs"),
+        ({"index_offset": 2, "num_jobs": 2}, "exceeds"),
+    ),
+)
+def test_run_sweep_validates_array_bounds(tmp_path, kwargs, message):
+    source = _write_sweep(tmp_path, [{"seed": 0}, {"seed": 1}, {"seed": 2}])
+    script = _write_job_script(tmp_path)
+
+    with pytest.raises(ValueError, match=message):
+        run_sweep_module.run_sweep(source, job_script=script, **kwargs)


### PR DESCRIPTION
## Summary

- add a model-agnostic Python sweep runner and indexed config executor
- add Docker and host-venv SLURM array job wrappers
- support chunked arrays, concurrency limits, CPU requests, node exclusions, configurable Docker resources, and existing MLflow parent IDs
- add a reusable finetuning example, documentation, and focused tests

## Why

The reusable sweep and SLURM logic previously lived only on `experimental_infra`, while `main` relied on experiment-specific launch scripts. This ports the generic pieces onto current `main` without bringing over RoBERTa/MNLI code or replacing newer training behavior.

## MLflow behavior

When any selected config enables MLflow, submission creates one parent run before calling `sbatch`. Parent creation is intentionally fail-loud: if tracking setup or parent creation fails, no array is submitted. `--parent-run-id` reuses an existing parent, and `--dry-run` performs no MLflow writes.

## Validation

- `18` focused tests passed
- Ruff passed for the new Python code and tests
- all new shell scripts passed `bash -n`
- the example sweep completed a side-effect-free dry run with the expected four-task array
